### PR TITLE
Backend: lock down CORS/WS origins + keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,34 @@
+# Keeps the Render free-tier backend awake so visitors don't hit a ~20s cold start.
+#
+# Render spins a free web service down after ~15 minutes of inactivity. This workflow
+# pings the public health endpoint on a schedule, which is enough traffic to keep the
+# instance running (and therefore keeps the 30s live-score scheduler + WebSocket alive).
+#
+# Caveats to be aware of:
+#   • GitHub's scheduled runs are best-effort and can be delayed under load, so the
+#     instance may occasionally still sleep — this *reduces* cold starts, it doesn't
+#     guarantee zero. The real fix is a paid always-on Render plan.
+#   • GitHub disables scheduled workflows on repos with no commits for 60 days.
+#   • A single free Render service kept warm fits within Render's monthly free hours.
+#
+# You can also trigger it by hand from the Actions tab (workflow_dispatch).
+name: Keep backend awake
+
+on:
+  schedule:
+    # Every 10 minutes, offset to :07 to avoid the top-of-hour stampede.
+    - cron: "7,17,27,37,47,57 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping backend health endpoint
+        run: |
+          # -m 90 allows for a cold start if it had already gone to sleep.
+          # --fail makes the step error on a 4xx/5xx so a broken backend shows up red.
+          curl --fail --silent --show-error -m 90 \
+            -o /dev/null \
+            -w "HTTP %{http_code} in %{time_total}s\n" \
+            https://onestopsports.onrender.com/api/sports

--- a/src/main/java/com/onestopsports/config/SecurityConfig.java
+++ b/src/main/java/com/onestopsports/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.onestopsports.config;
 
 import com.onestopsports.security.JwtAuthFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -26,6 +27,15 @@ public class SecurityConfig {
 
     // Our custom filter that checks the JWT token on every incoming request
     private final JwtAuthFilter jwtAuthFilter;
+
+    // Which website origins are allowed to call this API from a browser. Read from the
+    // `app.cors.allowed-origin-patterns` property (a comma-separated list) so we can add a
+    // new domain — e.g. a custom domain later — without editing any Java. These are Spring
+    // "origin patterns", so "*" wildcards are allowed (handy for Vercel's per-deploy preview
+    // URLs). The ":*" after the colon is a fallback used only if the property is missing
+    // (e.g. in some tests), where allowing any origin is harmless.
+    @Value("${app.cors.allowed-origin-patterns:*}")
+    private List<String> allowedOriginPatterns;
 
     public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
         this.jwtAuthFilter = jwtAuthFilter;
@@ -99,11 +109,13 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
-        // CORS (Cross-Origin Resource Sharing) controls which domains can call our API.
-        // The React frontend runs on localhost:5173 while the API is on localhost:8080 —
-        // without CORS config, the browser would block those cross-origin requests.
+        // CORS (Cross-Origin Resource Sharing) controls which website origins are allowed to
+        // call our API from a browser. In the Vercel split deploy the REST calls are proxied
+        // same-origin (so the browser doesn't even enforce CORS on them), but we still scope
+        // the allowed origins down from the old "*" to the configured list — defence in depth
+        // for any direct cross-origin call, and it keeps local dev working (localhost).
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*"));                              // Any origin (fine for dev)
+        configuration.setAllowedOriginPatterns(allowedOriginPatterns);                     // Only our known origins (dev + Vercel)
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // Allowed HTTP methods
         configuration.setAllowedHeaders(List.of("*"));                                    // Allow any header (incl. Authorization)
         configuration.setAllowCredentials(true);                                           // Allow cookies and auth headers

--- a/src/main/java/com/onestopsports/config/WebSocketConfig.java
+++ b/src/main/java/com/onestopsports/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.onestopsports.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.converter.DefaultContentTypeResolver;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -25,6 +26,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     // other registered modules, so LocalDateTime fields serialise to ISO-8601 strings.
     private final ObjectMapper objectMapper;
 
+    // Which website origins may open the live-scores WebSocket. Unlike the REST calls (which
+    // Vercel proxies same-origin), the browser connects this WebSocket straight from the
+    // Vercel site to the backend — a genuine cross-origin connection — so this list is what
+    // actually gates it. Read from the same `app.cors.allowed-origin-patterns` property the
+    // REST CORS config uses, so there's one place to manage allowed origins. ":*" is a
+    // fallback for when the property is absent (allows any origin — only hit in tests).
+    @Value("${app.cors.allowed-origin-patterns:*}")
+    private List<String> allowedOriginPatterns;
+
     public WebSocketConfig(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
@@ -46,8 +56,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // The frontend connects using @stomp/stompjs with a native ws:// URL,
         // which works in all modern browsers without any extra library.
         // SockJS was removed because its CJS module causes Vite to crash at import time.
+        // Only allow the configured origins (dev localhost + the Vercel site) to connect,
+        // instead of the old "*". setAllowedOriginPatterns takes varargs, so we hand it the
+        // list as an array.
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*"); // Allow connections from any origin (fine for dev)
+                .setAllowedOriginPatterns(allowedOriginPatterns.toArray(new String[0]));
     }
 
     // Override the STOMP message converter so it uses Spring Boot's ObjectMapper.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,18 @@ jwt:
   secret: bXlzdXBlcnNlY3JldGtleWZvcmptYXRjaGRheWFwcGxpY2F0aW9u
   expiration-ms: 86400000
 
+# Application-specific settings (our own, not Spring's).
+app:
+  cors:
+    # Website origins allowed to call the API / open the live-scores WebSocket from a browser.
+    # Comma-separated Spring "origin patterns" (so "*" wildcards are allowed). Used by both
+    # SecurityConfig (REST CORS) and WebSocketConfig (WS handshake). Add a custom domain here
+    # later — no Java change needed. Override per environment via the
+    # APP_CORS_ALLOWED_ORIGIN_PATTERNS env var (e.g. on Render).
+    #   • http://localhost:*                 — any local dev port (Vite runs on 3000)
+    #   • https://one-stop-sports*.vercel.app — the Vercel site + its preview/alias URLs
+    allowed-origin-patterns: http://localhost:*,https://one-stop-sports*.vercel.app
+
 server:
   port: 8081
 


### PR DESCRIPTION
Two production-hardening steps now that the app is publicly deployed (Vercel frontend + Render backend).

## Origin lockdown
`SecurityConfig` (REST CORS) and `WebSocketConfig` (live-scores WebSocket handshake) no longer allow `*`. Both now read a shared, configurable property **`app.cors.allowed-origin-patterns`** — default `http://localhost:*,https://one-stop-sports*.vercel.app`, overridable per-environment via `APP_CORS_ALLOWED_ORIGIN_PATTERNS`. The WS handshake is the one genuinely exercised cross-origin (browser → Render directly), so this is the meaningful gate. Resolves the "tighten CORS before public deploy" note in `CLAUDE.md`.

## Keep-alive workflow
`.github/workflows/keep-alive.yml` pings `…/api/sports` every 10 min to reduce Render free-tier cold starts (the ~20s wake-up). Best-effort (GitHub may delay schedules); the real fix remains a paid always-on plan. Runnable on demand via `workflow_dispatch`.

## Verification
- `mvn test` — all 66 green (the context-load test wires up both configs, confirming the `@Value` injection resolves).
- Pattern `https://one-stop-sports*.vercel.app` covers the live domain and Vercel's preview/alias URLs.

## Note after merge
Render auto-deploys `main`, so the backend will redeploy with the locked-down origins. No new env var is required (the default already includes the live Vercel domain); set `APP_CORS_ALLOWED_ORIGIN_PATTERNS` only if a custom domain is added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)